### PR TITLE
Add 25 health if the player has "The Lady" birthsign

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -735,6 +735,12 @@ local function modHealth(pid)
    temp = math.floor(Wil / 4)
    maxHP = math.floor(maxHP + temp)
 
+   -- Work-around for abilities not being saved to server
+   -- https://github.com/hristoast/ncgd-tes3mp/issues/3
+   if Players[pid].data.character.birthsign == "lady's favor" then
+      maxHP = maxHP + 25
+   end
+
    if currentHP > baseHP then
       currentHP = math.floor(currentHP / hpRatio)
 


### PR DESCRIPTION
Partial fix for #3. TES3MP cannot detect when spell effects are applied to the player, so we cannot account for diseases or abilities when recalculating health. It doesn't feel quite right to hard-code a fix like this, but this should address the most common use-case. I'll try a timer implementation as well. 