### PR TITLE
Allow importing players when decay is disabled

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -841,7 +841,6 @@ function ncgdTES3MP.OnPlayerSkill(eventStatus, pid)
 end
 
 function ncgdTES3MP.OnPlayerAuthentified(eventStatus, pid)
-    if not ncgdTES3MP.config.deathDecay.enabled and ncgdTES3MP.config.decayRate == none  then return end
     safelyRunEvent(eventStatus, "OnPlayerAuthentified", ncgdTES3MP.config.forceLoadOnPlayerAuthentified)
     info("Called \"OnPlayerAuthentified\" for pid \"" .. pid .. "\"")
     if not hasNCGDdata(pid) then
@@ -851,6 +850,7 @@ function ncgdTES3MP.OnPlayerAuthentified(eventStatus, pid)
                     .. "character is advised.  At any rate, have fun!" .. color.Default)
         initPlayer(pid)
     end
+    if not ncgdTES3MP.config.deathDecay.enabled and ncgdTES3MP.config.decayRate == none  then return end
     setCustomVar(pid, "loginPlayTime",
                  {
                      ["daysPassed"] = WorldInstance.data.time.daysPassed,


### PR DESCRIPTION
Currently on player authentication, we:

1. Stop if decay is completely disabled
2. Import non-NCGD players if applicable
3. Modify decay-related variables

If decay is completely disabled, non-NCGD players are then never imported, which seems like a bug (at least I needed that).

So, this PR just swaps steps 1 and 2